### PR TITLE
Fix the handling of combined source nets

### DIFF
--- a/src/getFullConnectivityMapFromCircuitJson.ts
+++ b/src/getFullConnectivityMapFromCircuitJson.ts
@@ -1,4 +1,4 @@
-import type { AnyCircuitElement } from "circuit-json"
+import type { AnyCircuitElement, PcbTraceRoutePointWire } from "circuit-json"
 import { findConnectedNetworks } from "./findConnectedNetworks"
 import { ConnectivityMap } from "./ConnectivityMap"
 
@@ -33,8 +33,11 @@ export const getFullConnectivityMapFromCircuitJson = (
       }
     } else if (element.type === "pcb_trace") {
       const { pcb_trace_id, source_trace_id } = element
-      const route = Array.isArray(element.route)
-        ? element.route.filter((rp) => rp && rp.route_type === "wire")
+      const route: PcbTraceRoutePointWire[] = Array.isArray(element.route)
+        ? (element.route.filter(
+            (rp): rp is PcbTraceRoutePointWire =>
+              rp != null && rp.route_type === "wire",
+          ) as PcbTraceRoutePointWire[])
         : []
 
       if (source_trace_id && pcb_trace_id) {
@@ -51,12 +54,14 @@ export const getFullConnectivityMapFromCircuitJson = (
         }
       }
 
-      if (Array.isArray(route) && route.length > 0 && pcb_trace_id) {
+      if (route.length > 0 && pcb_trace_id) {
         // Handle start/end port IDs independently
         const startId = route.find(
-          (rp) => rp?.start_pcb_port_id,
+          (rp: PcbTraceRoutePointWire) => rp.start_pcb_port_id,
         )?.start_pcb_port_id
-        const endId = route.find((rp) => rp?.end_pcb_port_id)?.end_pcb_port_id
+        const endId = route.find(
+          (rp: PcbTraceRoutePointWire) => rp.end_pcb_port_id,
+        )?.end_pcb_port_id
 
         if (startId) {
           connections.push([startId, pcb_trace_id])

--- a/src/getFullConnectivityMapFromCircuitJson.ts
+++ b/src/getFullConnectivityMapFromCircuitJson.ts
@@ -36,16 +36,33 @@ export const getFullConnectivityMapFromCircuitJson = (
       const route = Array.isArray(element.route)
         ? element.route.filter((rp) => rp && rp.route_type === "wire")
         : []
+
       if (source_trace_id && pcb_trace_id) {
-        connections.push([pcb_trace_id, source_trace_id])
+        // Handle combined source_trace_id like "source_net_4__source_net_5"
+        if (source_trace_id.includes("__")) {
+          const parts = source_trace_id.split("__")
+          for (const part of parts) {
+            if (part) {
+              connections.push([pcb_trace_id, part])
+            }
+          }
+        } else {
+          connections.push([pcb_trace_id, source_trace_id])
+        }
       }
-      if (Array.isArray(route)) {
+
+      if (Array.isArray(route) && route.length > 0 && pcb_trace_id) {
+        // Handle start/end port IDs independently
         const startId = route.find(
           (rp) => rp?.start_pcb_port_id,
         )?.start_pcb_port_id
         const endId = route.find((rp) => rp?.end_pcb_port_id)?.end_pcb_port_id
-        if (startId && pcb_trace_id && endId) {
-          connections.push([startId, pcb_trace_id, endId])
+
+        if (startId) {
+          connections.push([startId, pcb_trace_id])
+        }
+        if (endId) {
+          connections.push([endId, pcb_trace_id])
         }
       }
     } else if (element.type === "pcb_via") {


### PR DESCRIPTION
<img width="548" height="398" alt="Screenshot 2025-12-24 232648" src="https://github.com/user-attachments/assets/6a716b91-0f16-432d-bc64-fd27511e1ee5" />


**After**
<img width="546" height="403" alt="Screenshot 2025-12-24 233003" src="https://github.com/user-attachments/assets/c1a18c5a-4155-4c1e-8bd6-805ae2ff8789" />

 1. Split combined source_trace_id: When source_trace_id is like "source_net_4__source_net_5", split it and connect the trace to each part (source_net_4 and source_net_5)
  2. Handle port IDs independently: Connect start_pcb_port_id and end_pcb_port_id independently instead of requiring both

  No coordinate matching needed - this properly addresses the root cause (combined source_trace_id breaking the connectivity chain).
