### PR TITLE
Support PCB trace branch connectivity via connection_name IDs

### DIFF
--- a/src/getFullConnectivityMapFromCircuitJson.ts
+++ b/src/getFullConnectivityMapFromCircuitJson.ts
@@ -2,10 +2,54 @@ import type { AnyCircuitElement } from "circuit-json"
 import { findConnectedNetworks } from "./findConnectedNetworks"
 import { ConnectivityMap } from "./ConnectivityMap"
 
+type PcbTraceWithConnectionName = {
+  connection_name?: string
+}
+
+const getSourceConnectivityIds = (
+  circuitJson: AnyCircuitElement[],
+): Set<string> => {
+  const sourceConnectivityIds = new Set<string>()
+
+  for (const element of circuitJson) {
+    if (element.type === "source_trace") {
+      sourceConnectivityIds.add(element.source_trace_id)
+      for (const sourcePortId of element.connected_source_port_ids ?? []) {
+        sourceConnectivityIds.add(sourcePortId)
+      }
+      for (const sourceNetId of element.connected_source_net_ids ?? []) {
+        sourceConnectivityIds.add(sourceNetId)
+      }
+    } else if (element.type === "source_port") {
+      sourceConnectivityIds.add(element.source_port_id)
+    } else if (element.type === "source_net") {
+      sourceConnectivityIds.add(element.source_net_id)
+    } else if (element.type === "pcb_port") {
+      if (element.source_port_id) {
+        sourceConnectivityIds.add(element.source_port_id)
+      }
+    }
+  }
+
+  return sourceConnectivityIds
+}
+
+const getSourceConnectivityIdsFromConnectionName = (
+  connectionName: string | undefined,
+  sourceConnectivityIds: Set<string>,
+): string[] => {
+  if (!connectionName) return []
+
+  return connectionName
+    .split("__")
+    .filter((id) => sourceConnectivityIds.has(id))
+}
+
 export const getFullConnectivityMapFromCircuitJson = (
   circuitJson: AnyCircuitElement[],
 ) => {
   const connections: string[][] = []
+  const sourceConnectivityIds = getSourceConnectivityIds(circuitJson)
 
   for (const element of circuitJson) {
     if (element.type === "source_trace") {
@@ -33,11 +77,21 @@ export const getFullConnectivityMapFromCircuitJson = (
       }
     } else if (element.type === "pcb_trace") {
       const { pcb_trace_id, source_trace_id } = element
+      const connectionName = (element as PcbTraceWithConnectionName)
+        .connection_name
       const route = Array.isArray(element.route)
         ? element.route.filter((rp) => rp && rp.route_type === "wire")
         : []
       if (source_trace_id && pcb_trace_id) {
         connections.push([pcb_trace_id, source_trace_id])
+      }
+      const sourceIdsFromConnectionName =
+        getSourceConnectivityIdsFromConnectionName(
+          connectionName,
+          sourceConnectivityIds,
+        )
+      if (pcb_trace_id && sourceIdsFromConnectionName.length > 0) {
+        connections.push([pcb_trace_id, ...sourceIdsFromConnectionName])
       }
       if (Array.isArray(route)) {
         const startId = route.find(

--- a/tests/get-full-connectivity-map.test.ts
+++ b/tests/get-full-connectivity-map.test.ts
@@ -90,3 +90,68 @@ test("should handle internally_connected_source_port_ids in source_component for
   expect(result.areIdsConnected("p2", "p5")).toBe(true)
   expect(result.areIdsConnected("p1", "pcb_p5")).toBe(true)
 })
+
+test("should connect generated pcb trace branches by known ids in connection_name", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_2"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "source_trace_1__source_trace_2_mst0_0",
+      connection_name: "source_trace_1__source_trace_2",
+      route: [
+        { route_type: "wire", x: 0, y: 0, width: 0.2, layer: "top" },
+        { route_type: "wire", x: 1, y: 0, width: 0.2, layer: "top" },
+      ],
+    } as AnyCircuitElement,
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "source_trace_1__source_trace_2_mst1_0",
+      connection_name: "source_trace_1__source_trace_2",
+      route: [
+        { route_type: "wire", x: 10, y: 0, width: 0.2, layer: "top" },
+        { route_type: "wire", x: 11, y: 0, width: 0.2, layer: "top" },
+      ],
+    } as AnyCircuitElement,
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "source_trace_10__source_trace_11_mst0_0",
+      connection_name: "source_trace_10__source_trace_11",
+      route: [
+        { route_type: "wire", x: 20, y: 0, width: 0.2, layer: "top" },
+        { route_type: "wire", x: 21, y: 0, width: 0.2, layer: "top" },
+      ],
+    } as AnyCircuitElement,
+  ]
+
+  const result = getFullConnectivityMapFromCircuitJson(circuitJson)
+
+  expect(
+    result.areIdsConnected(
+      "source_trace_1__source_trace_2_mst0_0",
+      "source_trace_1__source_trace_2_mst1_0",
+    ),
+  ).toBe(true)
+  expect(
+    result.areIdsConnected(
+      "source_trace_1__source_trace_2_mst0_0",
+      "source_trace_1",
+    ),
+  ).toBe(true)
+  expect(
+    result.areIdsConnected(
+      "source_trace_10__source_trace_11_mst0_0",
+      "source_trace_1",
+    ),
+  ).toBe(false)
+})

--- a/tests/repro-breakout-sot23-regulator-overlap.test.ts
+++ b/tests/repro-breakout-sot23-regulator-overlap.test.ts
@@ -7,18 +7,18 @@ test("repro breakout sot23 regulator overlap connectivity", () => {
   const circuitJson = circuitJsonFixture as AnyCircuitElement[]
   const connMap = getFullConnectivityMapFromCircuitJson(circuitJson)
 
-  // BUG: these one-ended merged branch traces should be connected by the
-  // source_trace ids encoded in connection_name.
+  // These one-ended merged branch traces are connected by the source_trace ids
+  // encoded in connection_name.
   expect(
     connMap.areIdsConnected(
       "source_trace_3__source_trace_5_mst0_0",
       "source_trace_3__source_trace_5_mst1_0",
     ),
-  ).toBe(false)
+  ).toBe(true)
   expect(
     connMap.areIdsConnected(
       "source_trace_3__source_trace_5_mst0_0",
       "source_trace_3",
     ),
-  ).toBe(false)
+  ).toBe(true)
 })

--- a/tests/repro-breakout-sot23-regulator-power-rail.test.ts
+++ b/tests/repro-breakout-sot23-regulator-power-rail.test.ts
@@ -7,30 +7,30 @@ test("repro breakout sot23 regulator power rail connectivity", () => {
   const circuitJson = circuitJsonFixture as AnyCircuitElement[]
   const connMap = getFullConnectivityMapFromCircuitJson(circuitJson)
 
-  // BUG: these one-ended merged branch traces should be connected by the
-  // source_trace ids encoded in connection_name.
+  // These one-ended merged branch traces are connected by the source_trace ids
+  // encoded in connection_name.
   expect(
     connMap.areIdsConnected(
       "source_trace_7__source_trace_9_mst0_0",
       "source_trace_7__source_trace_9_mst1_0",
     ),
-  ).toBe(false)
+  ).toBe(true)
   expect(
     connMap.areIdsConnected(
       "source_trace_7__source_trace_9_mst0_0",
       "source_trace_7",
     ),
-  ).toBe(false)
+  ).toBe(true)
   expect(
     connMap.areIdsConnected(
       "source_trace_4__source_trace_8_mst0_0",
       "source_trace_4__source_trace_8_mst1_0",
     ),
-  ).toBe(false)
+  ).toBe(true)
   expect(
     connMap.areIdsConnected(
       "source_trace_4__source_trace_8_mst0_0",
       "source_trace_4",
     ),
-  ).toBe(false)
+  ).toBe(true)
 })


### PR DESCRIPTION
Adds ID-based connectivity for branched generated PCB traces by resolving connection_name entries against known source connectivity IDs in the same circuit JSON. Updates the merged repros to assert the fixed behavior and adds focused regression coverage.