### PR TITLE
Keep net ids and element ids as separate sets in areIdsConnected

### DIFF
--- a/src/ConnectivityMap.ts
+++ b/src/ConnectivityMap.ts
@@ -79,7 +79,9 @@ export class ConnectivityMap {
     if (!netId1) return false
     const netId2 = this.getNetConnectedToId(id2)
     if (!netId2) return false
-    return netId1 === netId2 || netId2 === id1 || netId2 === id1
+    // net ids and element ids are separate sets: a net id is not a substitute
+    // for an element id. To connect a net id, list it as a member of the net.
+    return netId1 === netId2
   }
 
   areAllIdsConnected(ids: string[]): boolean {

--- a/tests/connectivity-map-net-vs-id.test.ts
+++ b/tests/connectivity-map-net-vs-id.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "../src/ConnectivityMap"
+
+// net ids and element ids are separate sets. A net id (e.g. "connectivity_net0")
+// is not a substitute for an element id, so querying a net id against one of its
+// members returns false. To make a net id connectable, list it as a member.
+test("areIdsConnected treats net ids and element ids as separate sets", () => {
+  const connMap = new ConnectivityMap({
+    connectivity_net0: ["port1", "port2"],
+  })
+
+  // elements on the same net are connected
+  expect(connMap.areIdsConnected("port1", "port2")).toBe(true)
+
+  // a net id is not accepted as a stand-in for an element id
+  expect(connMap.areIdsConnected("connectivity_net0", "port1")).toBe(false)
+  expect(connMap.areIdsConnected("port1", "connectivity_net0")).toBe(false)
+})
+
+test("a net id becomes connectable when listed as a member of its net", () => {
+  const connMap = new ConnectivityMap({
+    connectivity_net0: ["connectivity_net0", "port1"],
+  })
+
+  expect(connMap.areIdsConnected("connectivity_net0", "port1")).toBe(true)
+  expect(connMap.areIdsConnected("port1", "connectivity_net0")).toBe(true)
+})


### PR DESCRIPTION
Per @seveibar's note: the connectivity map solver shouldn't accept connectivity nets as substitutes for element ids — they're different sets.

`areIdsConnected` ended with `return netId1 === netId2 || netId2 === id1 || netId2 === id1` (the last clause duplicated). Those trailing clauses tried to treat a net id as a stand-in for an element id. This drops them, so:

- a net id passed where an element id is expected returns `false` (nets ≠ ids)
- element↔element on the same net is unchanged
- to connect a net id, list it as a member of its net: `{ connectivity_net0: ["connectivity_net0", ...] }` — then normal resolution connects it, no special-casing

Added a test covering both (net id not a substitute; net id connectable once listed as a member). Existing tests unchanged.

Note: the red `type-check` is the pre-existing `rp` implicit-any on main — #23 fixes that separately.