### PR TITLE
Fix type-check error on main (rp implicitly any)

### DIFF
--- a/src/getFullConnectivityMapFromCircuitJson.ts
+++ b/src/getFullConnectivityMapFromCircuitJson.ts
@@ -1,4 +1,4 @@
-import type { AnyCircuitElement } from "circuit-json"
+import type { AnyCircuitElement, PcbTraceRoutePoint } from "circuit-json"
 import { findConnectedNetworks } from "./findConnectedNetworks"
 import { ConnectivityMap } from "./ConnectivityMap"
 
@@ -34,7 +34,9 @@ export const getFullConnectivityMapFromCircuitJson = (
     } else if (element.type === "pcb_trace") {
       const { pcb_trace_id, source_trace_id } = element
       const route = Array.isArray(element.route)
-        ? element.route.filter((rp) => rp && rp.route_type === "wire")
+        ? element.route.filter(
+            (rp: PcbTraceRoutePoint) => rp && rp.route_type === "wire",
+          )
         : []
       if (source_trace_id && pcb_trace_id) {
         connections.push([pcb_trace_id, source_trace_id])


### PR DESCRIPTION
`type-check` has been red , which means every PR shows a failing check. The one error:

```
src/getFullConnectivityMapFromCircuitJson.ts(37,33): error TS7006: Parameter 'rp' implicitly has an 'any' type.
```

Under the `element.type === "pcb_trace"` narrowing, `element.route` resolves to `any`, so the `.filter` callback param `rp` is implicitly `any` and `tsc --strict` rejects it. Annotating the param with the exported `PcbTraceRoutePoint` type fixes it (no `any`, no cast):

```ts
element.route.filter((rp: PcbTraceRoutePoint) => rp && rp.route_type === "wire")
```

Type-only change — the emitted JS is byte-identical, so no runtime effect. `bunx tsc --noEmit` now reports **zero** errors, and `biome format` leaves the file unchanged.