### PR TITLE
Add failing repro for source_component_internal_connection in the full map

### DIFF
--- a/tests/full-connectivity-map-internal-connection.test.ts
+++ b/tests/full-connectivity-map-internal-connection.test.ts
@@ -1,0 +1,25 @@
+import { test, expect } from "bun:test"
+import { getFullConnectivityMapFromCircuitJson } from "../src"
+import type { AnyCircuitElement } from "circuit-json"
+
+// getFullConnectivityMapFromCircuitJson has a branch for the older
+// source_component.internally_connected_source_port_ids but none for the
+// source_component_internal_connection element, so internally-connected ports
+// come back disconnected here even though
+// getSourcePortConnectivityMapFromCircuitJson honors them.
+test.failing(
+  "getFullConnectivityMapFromCircuitJson honors source_component_internal_connection",
+  () => {
+    const circuitJson: AnyCircuitElement[] = [
+      {
+        type: "source_component_internal_connection",
+        source_component_internal_connection_id: "internal_connection_1",
+        source_component_id: "source_component_1",
+        source_port_ids: ["source_port_1", "source_port_2"],
+      },
+    ]
+
+    const fullMap = getFullConnectivityMapFromCircuitJson(circuitJson)
+    expect(fullMap.areIdsConnected("source_port_1", "source_port_2")).toBe(true)
+  },
+)


### PR DESCRIPTION
Failing repro for #24.

`getFullConnectivityMapFromCircuitJson` has no branch for the `source_component_internal_connection` element (it only handles the older `source_component.internally_connected_source_port_ids`), so internally-connected ports come back disconnected there even though `getSourcePortConnectivityMapFromCircuitJson` honors them.

`test.failing` so this stays green; the fix (#26) adds the branch and flips it to `test`.