### PR TITLE
Honor source_component_internal_connection in the full connectivity map

### DIFF
--- a/src/getFullConnectivityMapFromCircuitJson.ts
+++ b/src/getFullConnectivityMapFromCircuitJson.ts
@@ -61,6 +61,8 @@ export const getFullConnectivityMapFromCircuitJson = (
           connections.push(portGroup)
         }
       }
+    } else if (element.type === "source_component_internal_connection") {
+      connections.push(element.source_port_ids)
     }
   }
 

--- a/tests/full-connectivity-map-internal-connection.test.ts
+++ b/tests/full-connectivity-map-internal-connection.test.ts
@@ -7,19 +7,16 @@ import type { AnyCircuitElement } from "circuit-json"
 // source_component_internal_connection element, so internally-connected ports
 // come back disconnected here even though
 // getSourcePortConnectivityMapFromCircuitJson honors them.
-test.failing(
-  "getFullConnectivityMapFromCircuitJson honors source_component_internal_connection",
-  () => {
-    const circuitJson: AnyCircuitElement[] = [
-      {
-        type: "source_component_internal_connection",
-        source_component_internal_connection_id: "internal_connection_1",
-        source_component_id: "source_component_1",
-        source_port_ids: ["source_port_1", "source_port_2"],
-      },
-    ]
+test("getFullConnectivityMapFromCircuitJson honors source_component_internal_connection", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component_internal_connection",
+      source_component_internal_connection_id: "internal_connection_1",
+      source_component_id: "source_component_1",
+      source_port_ids: ["source_port_1", "source_port_2"],
+    },
+  ]
 
-    const fullMap = getFullConnectivityMapFromCircuitJson(circuitJson)
-    expect(fullMap.areIdsConnected("source_port_1", "source_port_2")).toBe(true)
-  },
-)
+  const fullMap = getFullConnectivityMapFromCircuitJson(circuitJson)
+  expect(fullMap.areIdsConnected("source_port_1", "source_port_2")).toBe(true)
+})

--- a/tests/full-connectivity-map-internal-connection.test.ts
+++ b/tests/full-connectivity-map-internal-connection.test.ts
@@ -1,0 +1,25 @@
+import { test, expect } from "bun:test"
+import { getFullConnectivityMapFromCircuitJson } from "../src"
+import type { AnyCircuitElement } from "circuit-json"
+
+// getFullConnectivityMapFromCircuitJson has a branch for the older
+// source_component.internally_connected_source_port_ids but none for the
+// source_component_internal_connection element, so internally-connected ports
+// come back disconnected here even though
+// getSourcePortConnectivityMapFromCircuitJson honors them.
+test.failing(
+  "getFullConnectivityMapFromCircuitJson honors source_component_internal_connection",
+  () => {
+    const circuitJson: AnyCircuitElement[] = [
+      {
+        type: "source_component_internal_connection",
+        source_component_internal_connection_id: "internal_connection_1",
+        source_component_id: "source_component_1",
+        source_port_ids: ["source_port_1", "source_port_2"],
+      },
+    ]
+
+    const fullMap = getFullConnectivityMapFromCircuitJson(circuitJson)
+    expect(fullMap.areIdsConnected("source_port_1", "source_port_2")).toBe(true)
+  },
+)


### PR DESCRIPTION
Fixes #24. Builds on the repro in #25.

`getFullConnectivityMapFromCircuitJson` handled `source_component.internally_connected_source_port_ids` but had no branch for the `source_component_internal_connection` element, so internally-connected ports came back disconnected there while `getSourcePortConnectivityMapFromCircuitJson` reported them connected — the two maps disagreed on the same circuit-json.

Adds the matching branch (same as the source-port map already does):

```ts
} else if (element.type === "source_component_internal_connection") {
  connections.push(element.source_port_ids)
}
```

`element.source_port_ids` is typed `string[]`, so no cast. Repro test flips from `test.failing` to `test`; full suite stays green.