### PR TITLE
Stop addConnections reusing an existing net id

### DIFF
--- a/src/ConnectivityMap.ts
+++ b/src/ConnectivityMap.ts
@@ -29,18 +29,14 @@ export class ConnectivityMap {
 
       if (existingNets.size === 0) {
         // If no existing nets found, create a new one
-        targetNetId = `connectivity_net${Object.keys(this.netMap).length}`
+        targetNetId = this.getNextNetId()
         this.netMap[targetNetId] = []
       } else if (existingNets.size === 1) {
         // If only one existing net found, use it
-        targetNetId =
-          existingNets.values().next().value ??
-          `connectivity_net${Object.keys(this.netMap).length}`
+        targetNetId = existingNets.values().next().value ?? this.getNextNetId()
       } else {
         // If multiple nets found, merge them
-        targetNetId =
-          existingNets.values().next().value ??
-          `connectivity_net${Object.keys(this.netMap).length}`
+        targetNetId = existingNets.values().next().value ?? this.getNextNetId()
         for (const netId of existingNets) {
           if (netId !== targetNetId) {
             this.netMap[targetNetId].push(...this.netMap[netId])
@@ -63,6 +59,17 @@ export class ConnectivityMap {
         this.idToNetMap[id] = targetNetId
       }
     }
+  }
+
+  // Net keys are not always a dense 0..n-1 range (findConnectedNetworks can
+  // leave gaps), so pick the first connectivity_net<i> that is not already a
+  // key instead of deriving one from the key count, which would collide.
+  getNextNetId(): string {
+    let index = Object.keys(this.netMap).length
+    while (this.netMap[`connectivity_net${index}`] !== undefined) {
+      index++
+    }
+    return `connectivity_net${index}`
   }
 
   getIdsConnectedToNet(netId: string): string[] {

--- a/tests/addconnections-net-id-collision.test.ts
+++ b/tests/addconnections-net-id-collision.test.ts
@@ -5,16 +5,13 @@ import { ConnectivityMap } from "../src/ConnectivityMap"
 // them (e.g. just { connectivity_net1: [...] }). addConnections derived a NEW net
 // id from Object.keys(netMap).length, which collides with such a key and clobbers
 // the existing net.
-test.failing(
-  "addConnections does not reuse a net id already present in a gapped net map",
-  () => {
-    const connMap = new ConnectivityMap({ connectivity_net1: ["A", "B"] })
+test("addConnections does not reuse a net id already present in a gapped net map", () => {
+  const connMap = new ConnectivityMap({ connectivity_net1: ["A", "B"] })
 
-    connMap.addConnections([["X", "Y"]])
+  connMap.addConnections([["X", "Y"]])
 
-    // X/Y is a brand-new, unrelated connection: it must not merge into A/B's net
-    expect(connMap.areIdsConnected("A", "X")).toBe(false)
-    expect(connMap.areIdsConnected("A", "B")).toBe(true)
-    expect(connMap.areIdsConnected("X", "Y")).toBe(true)
-  },
-)
+  // X/Y is a brand-new, unrelated connection: it must not merge into A/B's net
+  expect(connMap.areIdsConnected("A", "X")).toBe(false)
+  expect(connMap.areIdsConnected("A", "B")).toBe(true)
+  expect(connMap.areIdsConnected("X", "Y")).toBe(true)
+})

--- a/tests/addconnections-net-id-collision.test.ts
+++ b/tests/addconnections-net-id-collision.test.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "bun:test"
+import { ConnectivityMap } from "../src/ConnectivityMap"
+
+// A net map can have gapped / non-sequential keys — findConnectedNetworks emits
+// them (e.g. just { connectivity_net1: [...] }). addConnections derived a NEW net
+// id from Object.keys(netMap).length, which collides with such a key and clobbers
+// the existing net.
+test.failing(
+  "addConnections does not reuse a net id already present in a gapped net map",
+  () => {
+    const connMap = new ConnectivityMap({ connectivity_net1: ["A", "B"] })
+
+    connMap.addConnections([["X", "Y"]])
+
+    // X/Y is a brand-new, unrelated connection: it must not merge into A/B's net
+    expect(connMap.areIdsConnected("A", "X")).toBe(false)
+    expect(connMap.areIdsConnected("A", "B")).toBe(true)
+    expect(connMap.areIdsConnected("X", "Y")).toBe(true)
+  },
+)


### PR DESCRIPTION
Fixes #27. Builds on the repro in #28.

`addConnections` minted a new net id as `connectivity_net${keys.length}`. Because net keys can be gapped (`findConnectedNetworks` creates then deletes intermediate nets), the count can point at an existing key — so a brand-new connection silently clobbered an existing net.

Adds `getNextNetId`, which returns the first `connectivity_net<i>` not already present, and uses it at every mint site:

```ts
getNextNetId(): string {
  let index = Object.keys(this.netMap).length
  while (this.netMap[`connectivity_net${index}`] !== undefined) {
    index++
  }
  return `connectivity_net${index}`
}
```

Repro test flips from `test.failing` to `test`; full suite green.