### PR TITLE
fix: prevent addConnections from reusing existing net id (#27)

### DIFF
--- a/src/ConnectivityMap.ts
+++ b/src/ConnectivityMap.ts
@@ -13,6 +13,14 @@ export class ConnectivityMap {
     }
   }
 
+  private getNextNetId(): string {
+    let counter = 0
+    while (this.netMap[`connectivity_net${counter}`]) {
+      counter++
+    }
+    return `connectivity_net${counter}`
+  }
+
   addConnections(connections: string[][]) {
     for (const connection of connections) {
       const existingNets = new Set<string>()
@@ -29,18 +37,14 @@ export class ConnectivityMap {
 
       if (existingNets.size === 0) {
         // If no existing nets found, create a new one
-        targetNetId = `connectivity_net${Object.keys(this.netMap).length}`
+        targetNetId = this.getNextNetId()
         this.netMap[targetNetId] = []
       } else if (existingNets.size === 1) {
         // If only one existing net found, use it
-        targetNetId =
-          existingNets.values().next().value ??
-          `connectivity_net${Object.keys(this.netMap).length}`
+        targetNetId = existingNets.values().next().value ?? this.getNextNetId()
       } else {
         // If multiple nets found, merge them
-        targetNetId =
-          existingNets.values().next().value ??
-          `connectivity_net${Object.keys(this.netMap).length}`
+        targetNetId = existingNets.values().next().value ?? this.getNextNetId()
         for (const netId of existingNets) {
           if (netId !== targetNetId) {
             this.netMap[targetNetId].push(...this.netMap[netId])

--- a/tests/connectivity-map-no-clobber.test.ts
+++ b/tests/connectivity-map-no-clobber.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "../src/ConnectivityMap"
+
+test("addConnections does not clobber existing net when net keys have gaps", () => {
+  const cm = new ConnectivityMap({ connectivity_net1: ["A", "B"] })
+  cm.addConnections([["X", "Y"]])
+
+  expect(cm.areIdsConnected("A", "X")).toBe(false)
+  expect(cm.getIdsConnectedToNet("connectivity_net1")).toEqual(["A", "B"])
+})


### PR DESCRIPTION
## Summary

Closes #27

When `netMap` contains gaps in numerical suffixes (e.g. `connectivity_net1` without `connectivity_net0`), `Object.keys(this.netMap).length` evaluates to an existing net key, causing `addConnections` to overwrite existing net definitions.

This PR introduces `getNextNetId()`, which searches for the first non-colliding `connectivity_net<i>` key before assigning new net IDs.

## Testing

- Added unit test `tests/connectivity-map-no-clobber.test.ts` reproducing the issue scenario.
- All 14 tests pass 100%.
