### PR TITLE
fix: keep cross-layer PCB traces disconnected

### DIFF
--- a/src/PcbConnectivityMap.ts
+++ b/src/PcbConnectivityMap.ts
@@ -99,12 +99,15 @@ export class PcbConnectivityMap {
       const segment1B = trace1.route[i + 1]
       if (segment1A.route_type !== "wire") continue
       if (segment1B.route_type !== "wire") continue
+      if (segment1A.layer !== segment1B.layer) continue
       for (let j = 0; j < trace2.route.length - 1; j++) {
         const segment2A = trace2.route[j]
         const segment2B = trace2.route[j + 1]
 
         if (segment2A.route_type !== "wire") continue
         if (segment2B.route_type !== "wire") continue
+        if (segment2A.layer !== segment2B.layer) continue
+        if (segment1A.layer !== segment2A.layer) continue
 
         // Check if lines are overlapping
         const isOverlapping = doesLineIntersectLine(

--- a/tests/pcb-connectivity-map-layers.test.ts
+++ b/tests/pcb-connectivity-map-layers.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { PcbConnectivityMap } from "../src/PcbConnectivityMap"
+
+test("crossing PCB traces on different layers are not connected", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "top_trace",
+      route: [
+        { x: -1, y: 0, route_type: "wire", width: 0.2, layer: "top" },
+        { x: 1, y: 0, route_type: "wire", width: 0.2, layer: "top" },
+      ],
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "bottom_trace",
+      route: [
+        { x: 0, y: -1, route_type: "wire", width: 0.2, layer: "bottom" },
+        { x: 0, y: 1, route_type: "wire", width: 0.2, layer: "bottom" },
+      ],
+    },
+  ]
+
+  const connectivityMap = new PcbConnectivityMap(circuitJson)
+
+  expect(connectivityMap.areTracesConnected("top_trace", "bottom_trace")).toBe(
+    false,
+  )
+})
+
+test("crossing PCB traces on the same layer remain connected", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "horizontal_trace",
+      route: [
+        { x: -1, y: 0, route_type: "wire", width: 0.2, layer: "top" },
+        { x: 1, y: 0, route_type: "wire", width: 0.2, layer: "top" },
+      ],
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "vertical_trace",
+      route: [
+        { x: 0, y: -1, route_type: "wire", width: 0.2, layer: "top" },
+        { x: 0, y: 1, route_type: "wire", width: 0.2, layer: "top" },
+      ],
+    },
+  ]
+
+  const connectivityMap = new PcbConnectivityMap(circuitJson)
+
+  expect(
+    connectivityMap.areTracesConnected("horizontal_trace", "vertical_trace"),
+  ).toBe(true)
+})


### PR DESCRIPTION
Fixes #31.

## What changed
- require each compared wire segment to stay on one copper layer
- skip geometric intersection checks when the two segments are on different layers
- add a focused cross-layer regression plus a same-layer control

## Verification
- `bun test` — 15 passed
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`
- `git diff --check`