### PR TITLE
fix: keep crossing traces on different layers disconnected (#31)

### DIFF
--- a/src/PcbConnectivityMap.ts
+++ b/src/PcbConnectivityMap.ts
@@ -1,6 +1,6 @@
+import { doesLineIntersectLine } from "@tscircuit/math-utils"
 import type { AnyCircuitElement, PCBPort, PCBTrace } from "circuit-json"
 import { ConnectivityMap } from "./ConnectivityMap"
-import { doesLineIntersectLine } from "@tscircuit/math-utils"
 import { findConnectedNetworks } from "./findConnectedNetworks"
 
 /**
@@ -105,6 +105,17 @@ export class PcbConnectivityMap {
 
         if (segment2A.route_type !== "wire") continue
         if (segment2B.route_type !== "wire") continue
+
+        // Traces on different copper layers can cross geometrically without
+        // being electrically connected — only compare same-layer segments
+        // (https://github.com/tscircuit/circuit-json-to-connectivity-map/issues/31)
+        if (
+          segment1A.layer &&
+          segment2A.layer &&
+          segment1A.layer !== segment2A.layer
+        ) {
+          continue
+        }
 
         // Check if lines are overlapping
         const isOverlapping = doesLineIntersectLine(

--- a/tests/cross-layer-traces-not-connected-31.test.ts
+++ b/tests/cross-layer-traces-not-connected-31.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test"
+import type { PCBTrace } from "circuit-json"
+import { PcbConnectivityMap } from "../src/PcbConnectivityMap"
+
+// https://github.com/tscircuit/circuit-json-to-connectivity-map/issues/31
+//
+// _arePcbTracesConnected checked geometric intersection without comparing
+// route-point layers, so a top-layer trace crossing a bottom-layer trace
+// was reported as electrically connected even though there is no via.
+test("crossing traces on different layers are not connected", () => {
+  const map = new PcbConnectivityMap([
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "top_trace",
+      route: [
+        { x: -1, y: 0, route_type: "wire", width: 0.2, layer: "top" },
+        { x: 1, y: 0, route_type: "wire", width: 0.2, layer: "top" },
+      ],
+    } as PCBTrace,
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "bottom_trace",
+      route: [
+        { x: 0, y: -1, route_type: "wire", width: 0.2, layer: "bottom" },
+        { x: 0, y: 1, route_type: "wire", width: 0.2, layer: "bottom" },
+      ],
+    } as PCBTrace,
+  ])
+
+  expect(map.areTracesConnected("top_trace", "bottom_trace")).toBe(false)
+})
+
+test("crossing traces on the same layer remain connected", () => {
+  const map = new PcbConnectivityMap([
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "trace_a",
+      route: [
+        { x: -1, y: 0, route_type: "wire", width: 0.2, layer: "top" },
+        { x: 1, y: 0, route_type: "wire", width: 0.2, layer: "top" },
+      ],
+    } as PCBTrace,
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "trace_b",
+      route: [
+        { x: 0, y: -1, route_type: "wire", width: 0.2, layer: "top" },
+        { x: 0, y: 1, route_type: "wire", width: 0.2, layer: "top" },
+      ],
+    } as PCBTrace,
+  ])
+
+  expect(map.areTracesConnected("trace_a", "trace_b")).toBe(true)
+})


### PR DESCRIPTION
Fixes #31.

## Problem

`PcbConnectivityMap._arePcbTracesConnected` checks geometric intersection without comparing route-point layers, so a top-layer trace crossing a bottom-layer trace is reported as electrically connected even though there is no via.

## Fix

Segments are only compared when they share a layer. Segments without layer info keep the previous behavior (still compared), so untyped/legacy routes are unaffected.

```ts
if (
  segment1A.layer &&
  segment2A.layer &&
  segment1A.layer !== segment2A.layer
) {
  continue
}
```

## Verification

- The issue's minimal repro added as a regression test — fails on `main` (`areTracesConnected("top_trace", "bottom_trace")` returned `true`), passes here
- Same-layer control test: crossing traces on one layer remain connected
- Full suite: 15 pass, 0 fail; `bunx tsc --noEmit` / `biome check` clean

Note on the prior attempt #32: it was closed by its author for policy reasons unrelated to the technical approach. This PR uses the repro exactly as posted in the issue by @Hero988.
