### PR TITLE
Connect PCB vias through source trace IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format": "biome format --write ."
   },
   "devDependencies": {
-    "circuit-json": "^0.0.432",
+    "circuit-json": "^0.0.458",
     "@biomejs/biome": "^1.9.0",
     "@types/bun": "^1.3.4",
     "tsup": "^8.2.4"

--- a/src/getFullConnectivityMapFromCircuitJson.ts
+++ b/src/getFullConnectivityMapFromCircuitJson.ts
@@ -51,10 +51,7 @@ export const getFullConnectivityMapFromCircuitJson = (
         }
       }
     } else if (element.type === "pcb_via") {
-      const { pcb_via_id, pcb_trace_id, source_trace_id } =
-        element as typeof element & {
-          source_trace_id?: string
-        }
+      const { pcb_via_id, pcb_trace_id, source_trace_id } = element
       const connectedTraceIds = [pcb_trace_id, source_trace_id].filter(
         (traceId): traceId is string => Boolean(traceId),
       )

--- a/src/getFullConnectivityMapFromCircuitJson.ts
+++ b/src/getFullConnectivityMapFromCircuitJson.ts
@@ -51,9 +51,15 @@ export const getFullConnectivityMapFromCircuitJson = (
         }
       }
     } else if (element.type === "pcb_via") {
-      const { pcb_via_id, pcb_trace_id } = element
-      if (pcb_trace_id && pcb_via_id) {
-        connections.push([pcb_via_id, pcb_trace_id])
+      const { pcb_via_id, pcb_trace_id, source_trace_id } =
+        element as typeof element & {
+          source_trace_id?: string
+        }
+      const connectedTraceIds = [pcb_trace_id, source_trace_id].filter(
+        (traceId): traceId is string => Boolean(traceId),
+      )
+      if (pcb_via_id && connectedTraceIds.length > 0) {
+        connections.push([pcb_via_id, ...connectedTraceIds])
       }
     } else if (element.type === "source_component") {
       if (element.internally_connected_source_port_ids) {

--- a/tests/get-full-connectivity-map.test.ts
+++ b/tests/get-full-connectivity-map.test.ts
@@ -90,3 +90,26 @@ test("should handle internally_connected_source_port_ids in source_component for
   expect(result.areIdsConnected("p2", "p5")).toBe(true)
   expect(result.areIdsConnected("p1", "pcb_p5")).toBe(true)
 })
+
+test("should connect a pcb via through its source trace", () => {
+  const circuitJson = [
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1"],
+    },
+    {
+      type: "pcb_via",
+      pcb_via_id: "pcb_via_1",
+      source_trace_id: "source_trace_1",
+      x: 0,
+      y: 0,
+      layers: ["top", "bottom"],
+    },
+  ] as AnyCircuitElement[]
+
+  const result = getFullConnectivityMapFromCircuitJson(circuitJson)
+
+  expect(result.areIdsConnected("pcb_via_1", "source_trace_1")).toBe(true)
+  expect(result.areIdsConnected("pcb_via_1", "source_port_1")).toBe(true)
+})

--- a/tests/get-full-connectivity-map.test.ts
+++ b/tests/get-full-connectivity-map.test.ts
@@ -92,7 +92,7 @@ test("should handle internally_connected_source_port_ids in source_component for
 })
 
 test("should connect a pcb via through its source trace", () => {
-  const circuitJson = [
+  const circuitJson: AnyCircuitElement[] = [
     {
       type: "source_trace",
       source_trace_id: "source_trace_1",
@@ -106,7 +106,7 @@ test("should connect a pcb via through its source trace", () => {
       y: 0,
       layers: ["top", "bottom"],
     },
-  ] as AnyCircuitElement[]
+  ]
 
   const result = getFullConnectivityMapFromCircuitJson(circuitJson)
 


### PR DESCRIPTION
## Summary

- connect `pcb_via` records to their `source_trace_id` in the full connectivity map
- preserve support for the existing `pcb_trace_id` relationship during migration
- verify the via, source trace, source port chain is connected
- consume the native field from `circuit-json@^0.0.458`

## Testing

- `bun test` (14 passing)
- `bun run build`
- `bun run format:check`
- `git diff --check`

Built on the schema released by tscircuit/circuit-json#672. Part of tscircuit/tscircuit#4205 and supports tscircuit/core#2965.
