### PR TITLE
Connect PCB vias directly to source nets

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "format": "biome format --write ."
   },
   "devDependencies": {
-    "circuit-json": "^0.0.458",
     "@biomejs/biome": "^1.9.0",
     "@types/bun": "^1.3.4",
+    "circuit-json": "0.0.460",
     "tsup": "^8.2.4"
   },
   "peerDependencies": {

--- a/src/getFullConnectivityMapFromCircuitJson.ts
+++ b/src/getFullConnectivityMapFromCircuitJson.ts
@@ -52,11 +52,15 @@ export const getFullConnectivityMapFromCircuitJson = (
       }
     } else if (element.type === "pcb_via") {
       const { pcb_via_id, pcb_trace_id, source_trace_id } = element
-      const connectedTraceIds = [pcb_trace_id, source_trace_id].filter(
-        (traceId): traceId is string => Boolean(traceId),
+      const sourceNetId =
+        "source_net_id" in element && typeof element.source_net_id === "string"
+          ? element.source_net_id
+          : undefined
+      const connectedIds = [pcb_trace_id, source_trace_id, sourceNetId].filter(
+        (connectedId): connectedId is string => Boolean(connectedId),
       )
-      if (pcb_via_id && connectedTraceIds.length > 0) {
-        connections.push([pcb_via_id, ...connectedTraceIds])
+      if (pcb_via_id && connectedIds.length > 0) {
+        connections.push([pcb_via_id, ...connectedIds])
       }
     } else if (element.type === "source_component") {
       if (element.internally_connected_source_port_ids) {

--- a/src/getFullConnectivityMapFromCircuitJson.ts
+++ b/src/getFullConnectivityMapFromCircuitJson.ts
@@ -51,14 +51,13 @@ export const getFullConnectivityMapFromCircuitJson = (
         }
       }
     } else if (element.type === "pcb_via") {
-      const { pcb_via_id, pcb_trace_id, source_trace_id } = element
-      const sourceNetId =
-        "source_net_id" in element && typeof element.source_net_id === "string"
-          ? element.source_net_id
-          : undefined
-      const connectedIds = [pcb_trace_id, source_trace_id, sourceNetId].filter(
-        (connectedId): connectedId is string => Boolean(connectedId),
-      )
+      const { pcb_via_id, pcb_trace_id, source_trace_id, source_net_id } =
+        element
+      const connectedIds = [
+        pcb_trace_id,
+        source_trace_id,
+        source_net_id,
+      ].filter((connectedId): connectedId is string => Boolean(connectedId))
       if (pcb_via_id && connectedIds.length > 0) {
         connections.push([pcb_via_id, ...connectedIds])
       }

--- a/tests/get-full-connectivity-map.test.ts
+++ b/tests/get-full-connectivity-map.test.ts
@@ -113,3 +113,26 @@ test("should connect a pcb via through its source trace", () => {
   expect(result.areIdsConnected("pcb_via_1", "source_trace_1")).toBe(true)
   expect(result.areIdsConnected("pcb_via_1", "source_port_1")).toBe(true)
 })
+
+test("should connect a pcb via directly to its source net", () => {
+  const circuitJson = [
+    {
+      type: "source_net",
+      source_net_id: "source_net_gnd",
+      name: "GND",
+      member_source_group_ids: [],
+    },
+    {
+      type: "pcb_via",
+      pcb_via_id: "pcb_via_gnd",
+      source_net_id: "source_net_gnd",
+      x: 0,
+      y: 0,
+      layers: ["top", "bottom"],
+    },
+  ] as AnyCircuitElement[]
+
+  const result = getFullConnectivityMapFromCircuitJson(circuitJson)
+
+  expect(result.areIdsConnected("pcb_via_gnd", "source_net_gnd")).toBe(true)
+})


### PR DESCRIPTION
## Summary

- include pcb_via.source_net_id in full connectivity-map construction
- preserve existing pcb_trace_id and source_trace_id relationships
- add direct PCB-via-to-source-net regression coverage
- consume the released Circuit JSON 0.0.460 field directly

This allows routing checks and short detection to recognize physical contact between a net-assigned via and other copper on that source net without inventing a source trace.

Depends on merged tscircuit/circuit-json#676.
Part of tscircuit/tscircuit#4205.

## Validation

- bun test
- bun run build
- bun run format:check
- git diff --check
